### PR TITLE
map_files_to_assessment_item refactor

### DIFF
--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -60,11 +60,11 @@ class StudioTestCase(TestCase, BucketTestMixin):
         client.force_authenticate(self.admin_user)
         return client
 
-    def upload_temp_file(self, data, ext='.txt'):
+    def upload_temp_file(self, data, preset='document', ext='pdf'):
         """
         Uploads a file to the server using an authorized client.
         """
-        fileobj_temp = testdata.create_temp_file(data, ext=ext)
+        fileobj_temp = testdata.create_temp_file(data, preset=preset, ext=ext)
         name = fileobj_temp['name']
 
         f = SimpleUploadedFile(name, data)

--- a/contentcuration/contentcuration/tests/test_createchannel.py
+++ b/contentcuration/contentcuration/tests/test_createchannel.py
@@ -69,10 +69,10 @@ class CreateChannelTestCase(BaseTestCase):
         super(CreateChannelTestCase, self).setUp()
         self.topic = cc.ContentKind.objects.get(kind='topic')
         self.license = cc.License.objects.all()[0]
-        self.fileobj_audio = create_temp_file("abc", 'audio', 'mp3', 'application/audio')
-        self.fileobj_video = create_temp_file("def", 'video', 'mp4', 'application/video')
-        self.fileobj_document = create_temp_file("ghi", 'document', 'pdf', 'application/pdf')
-        self.fileobj_exercise = create_temp_file("jkl", 'exercise', 'perseus', 'application/perseus')
+        self.fileobj_audio = create_temp_file("abc", preset='audio', ext='mp3')
+        self.fileobj_video = create_temp_file("def", preset='high_res_video', ext='mp4')
+        self.fileobj_document = create_temp_file("ghi", preset='document', ext='pdf')
+        self.fileobj_exercise = create_temp_file("jkl", preset='exercise', ext='perseus')
 
     def create_channel(self):
         create_channel_url = str(reverse_lazy('api_create_channel'))

--- a/contentcuration/contentcuration/tests/test_zipcontentview.py
+++ b/contentcuration/contentcuration/tests/test_zipcontentview.py
@@ -37,7 +37,7 @@ class ZipFileTestCase(BaseTestCase):
         myzip = self.do_create_zip()
 
         self.sign_in()
-        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), ext='.zip')
+        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), preset='html5_zip', ext='zip')
         assert response.status_code == 200
         url = '{}{}/'.format(self.zipfile_url, temp_file['name'])
         response = self.get(url)
@@ -47,7 +47,7 @@ class ZipFileTestCase(BaseTestCase):
         myzip = self.do_create_zip()
 
         self.sign_in()
-        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), ext='.zip')
+        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), preset='html5_zip', ext='zip')
         assert response.status_code == 200
         url = '{}{}/index.html'.format(self.zipfile_url, temp_file['name'])
         response = self.get(url)
@@ -57,7 +57,7 @@ class ZipFileTestCase(BaseTestCase):
         myzip = self.do_create_zip()
 
         self.sign_in()
-        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), ext='.zip')
+        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), preset='html5_zip', ext='zip')
         assert response.status_code == 200
         url = '{}{}/iamjustanillusion.txt'.format(self.zipfile_url, temp_file['name'])
         response = self.get(url)
@@ -67,7 +67,7 @@ class ZipFileTestCase(BaseTestCase):
         myzip = self.do_create_zip()
 
         self.sign_in()
-        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), ext='.zip')
+        temp_file, response = self.upload_temp_file(open(myzip, 'rb').read(), preset='html5_zip', ext='zip')
         assert response.status_code == 200
         url = '{}{}/../outsidejson.js'.format(self.zipfile_url, temp_file['name'])
         response = self.get(url)

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -244,3 +244,21 @@ invalid_file_json = [
 
     }
 ]
+
+
+
+def fileobj_exercise_image():
+    """
+    Create a generic exercise image file in storage and return a File model pointing to it.
+    """
+    filecontents = "".join(random.sample(string.printable, 20))
+    temp_file_dict = create_temp_file(filecontents, preset=format_presets.EXERCISE_IMAGE, ext='jpg')
+    return temp_file_dict['db_file']
+
+def fileobj_exercise_graphie():
+    """
+    Create an graphi exercise image file in storage and return a File model pointing to it.
+    """
+    filecontents = "".join(random.sample(string.printable, 20))
+    temp_file_dict = create_temp_file(filecontents, preset=format_presets.EXERCISE_GRAPHIE, ext='graphie', original_filename='theoriginalfilename')
+    return temp_file_dict['db_file']

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -39,7 +39,7 @@ def topic():
 
 def exercise():
     """
-    Create a topic content kind.
+    Create a exercise content kind.
     """
     return mixer.blend(cc.ContentKind, kind='exercise')
 
@@ -73,34 +73,17 @@ def license_wtfpl():
 
 def fileobj_video(contents=None):
     """
-    Create an "mp4" video file on storage, and then create a File model pointing to it.
+    Create an "mp4" video file on storage and return a File model pointing to it.
 
-    if contents is given and is a string, then write said contents to the file. If not given,
-    a random string is generated and set as the contents of the file.
+    if contents is given and is a string, then write said contents to the file.
+    If no contents is given, a random string is generated and set as the contents of the file.
     """
     if contents:
         filecontents = contents
     else:
         filecontents = "".join(random.sample(string.printable, 20))
-
-    fileobj = StringIO(filecontents)
-    digest = md5.new(filecontents).hexdigest()
-    filename = "{}.mp4".format(digest)
-    storage_file_path = cc.generate_object_storage_name(digest, filename)
-
-    # Write out the file bytes on to object storage, with a filename specified with randomfilename
-    default_storage.save(storage_file_path, fileobj)
-
-    # then create a File object with that
-    db_file_obj = mixer.blend(
-        cc.File,
-        file_format=fileformat_mp4(),
-        checksum=digest,
-        preset=preset_video(),
-        file_on_disk=storage_file_path,
-    )
-
-    return db_file_obj
+    temp_file_dict = create_temp_file(filecontents, preset=format_presets.VIDEO_HIGH_RES, ext='mp4')
+    return temp_file_dict['db_file']
 
 
 def node_json(data):

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tests for contentcuration.views.internal functions.
 """
@@ -7,32 +8,34 @@ from mixer.main import mixer
 from contentcuration.models import ContentNode
 
 from ..base import StudioTestCase
-from ..testdata import tree, fileobj_video
+from ..testdata import tree, fileobj_video, fileobj_exercise_image, fileobj_exercise_graphie
+
+
+class SampleContentNodeDataSchema:
+    """
+    A class schema that we use to autogenerate parts of the
+    JSON data we send to api_add_nodes_to_tree. Pair this with
+    mixer.blend to autogenerate the schema with random values.
+    """
+    title = str
+    description = str
+    node_id = str
+    content_id = str
+    source_domain = str
+    source_id = str
+    author = str
+    copyright_holder = str
+
 
 class ApiAddNodesToTreeTestCase(StudioTestCase):
     """
     Tests for contentcuration.views.internal.api_add_nodes_to_tree function.
     """
 
-    class SampleNodeDataSchema:
-        """
-        A class schema that we use to autogenerate parts of the
-        JSON data we send to api_add_nodes_to_tree. Pair this with
-        mixer.blend to autogenerate the schema with random values.
-        """
-        title = str
-        description = str
-        node_id = str
-        content_id = str
-        source_domain = str
-        source_id = str
-        author = str
-        copyright_holder = str
-
     def setUp(self):
         super(ApiAddNodesToTreeTestCase, self).setUp()
         # get our random data from mixer
-        random_data = mixer.blend(self.SampleNodeDataSchema)
+        random_data = mixer.blend(SampleContentNodeDataSchema)
         self.root_node = tree()
         self.fileobj = fileobj_video()
         self.title = random_data.title
@@ -68,15 +71,10 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                 }
             ]
         }
-
-        serialized_data = json.dumps(sample_data)
-
         self.resp = self.admin_client().post(
             "/api/internal/add_nodes",
-            data=serialized_data,
-            # remember to set content_type to json, so django will
-            # decode it
-            content_type="application/json"
+            data=sample_data,
+            format='json'
         )
 
     def test_returns_200_status_code(self):
@@ -109,3 +107,145 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         # check that we can read the file and it's equivalent to
         # our original file object
         assert f.file_on_disk.read() == self.fileobj.file_on_disk.read()
+
+
+
+class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
+    """
+    Tests for contentcuration.views.internal.api_add_nodes_to_tree function for nodes
+    of type Exercise that contain questions with associated image files.
+    """
+
+    def setUp(self):
+        super(ApiAddExerciseNodesToTreeTestCase, self).setUp()
+        # get our random data from mixer
+        random_data = mixer.blend(SampleContentNodeDataSchema)
+        self.root_node = tree()
+        self.exercise_image = fileobj_exercise_image()          # a vanilla image file associated with question
+        self.exercise_graphie = fileobj_exercise_graphie()      # a perseus image file associated with question
+        self.title = random_data.title
+        sample_data = {
+            "root_id": self.root_node.id,
+            "content_data": [
+                {
+                    "title": self.title,
+                    "language": "en",
+                    "description": random_data.description,
+                    "node_id": random_data.node_id,
+                    "content_id": random_data.content_id,
+                    "source_domain": random_data.source_domain,
+                    "source_id": random_data.source_id,
+                    "author": random_data.author,
+                    "files": [],
+                    "kind": "exercise",
+                    "license": "CC BY",
+                    "license_description": None,
+                    "copyright_holder": random_data.copyright_holder,
+                    "questions": [
+                        {
+                            "assessment_id": "abf45e8fd7f151adb1b3df2d751e945e",
+                            "type": "multiple_selection",
+                            "files": [
+                                {
+                                    "size": self.exercise_image.file_size,
+                                    "preset": "exercise_image",
+                                    "filename": self.exercise_image.filename(),
+                                    "original_filename": None,
+                                    "language": None,
+                                    "source_url": None
+                                }
+                            ],
+                            "question": u"Which numbers are even?\n\nTest local image include: ![](${☣ CONTENTSTORAGE}/%s)" % self.exercise_image.filename(),
+                            "hints": "[]",
+                            "answers": "[{\"answer\": \"1\", \"correct\": false, \"order\": 0}, {\"answer\": \"2\", \"correct\": True, \"order\": 1}, {\"answer\": \"3\", \"correct\": false, \"order\": 2}, {\"answer\": \"4\", \"correct\": true, \"order\": 3}, {\"answer\": \"5\", \"correct\": false, \"order\": 4}]",
+                            "raw_data": "",
+                            "source_url": None,
+                            "randomize": False
+                        },
+                        {
+                            "assessment_id": "98856e24d53b57ea9023782ab6018767",
+                            "type": "perseus_question",
+                            "files": [
+                                {
+                                    "size": self.exercise_graphie.file_size,
+                                    "preset": "exercise_graphie",
+                                    "filename": self.exercise_graphie.filename(),
+                                    "original_filename": self.exercise_graphie.original_filename,
+                                    "language": None,
+                                    "source_url": None
+                                }
+                            ],
+                            "question": "",
+                            "hints": "[]",
+                            "answers": "[]",
+                            "raw_data": u"{\"question\": {\"content\": \"What was the main idea in the passage you just read?\\n\\n[[☃ radio 1]]\\n\\n Test web+graphie image ![graph](web+graphie:${☣ CONTENTSTORAGE}/%s)\", \"images\": {}, \"widgets\": {\"radio 1\": {\"type\": \"radio\", \"alignment\": \"default\", \"static\": false, \"graded\": true, \"options\": {\"choices\": [{\"content\": \"The right answer\", \"correct\": true}, {\"content\": \"Another option\", \"correct\": false}, {\"isNoneOfTheAbove\": false, \"content\": \"Nope, not this\", \"correct\": false}], \"randomize\": false, \"multipleSelect\": false, \"countChoices\": false, \"displayCount\": null, \"hasNoneOfTheAbove\": false, \"deselectEnabled\": false}, \"version\": {\"major\": 1, \"minor\": 0}}}}, \"answerArea\": {\"calculator\": false, \"chi2Table\": false, \"periodicTable\": false, \"tTable\": false, \"zTable\": false}, \"itemDataVersion\": {\"major\": 0, \"minor\": 1}, \"hints\": []}" % self.exercise_graphie.original_filename,
+                            "source_url": None,
+                            "randomize": False
+                        }
+                    ],
+                    "extra_fields": "{\"mastery_model\": \"m_of_n\", \"randomize\": true, \"m\": 1, \"n\": 2}",
+                    "role": "learner"
+                }
+            ]
+        }
+        self.resp = self.admin_client().post(
+            "/api/internal/add_nodes",
+            data=sample_data,
+            format='json'
+        )
+
+    def test_returns_200_status_code(self):
+        """
+        Check that we return 200 if passed in a valid JSON.
+        """
+        # check that we returned 200 with that POST request
+        assert self.resp.status_code == 200, "Got a request error: {}".format(self.resp.content)
+
+    def test_creates_nodes(self):
+        """
+        Test that it creates a node with the given title and parent.
+        """
+        # make sure a node with our given self.title exists, with the given parent.
+        assert ContentNode.get_nodes_with_title(title=self.title, limit_to_children_of=self.root_node.id).exists()
+
+    def test_associated_assesment_items_with_created_node(self):
+        """
+        Check that the file we created beforehand is now associated
+        with the node we just created through add_nodes.
+        """
+        c = ContentNode.objects.get(title=self.title)
+
+        # there shold be no files associated with the condent node
+        assert len(c.files.all()) == 0, 'unexpected files created'
+        # get the associated assessment items...
+        assessment_items = list(c.assessment_items.order_by('order'))
+        # there should be two assesment items associated with the condent node
+        assert len(assessment_items) == 2, 'should have two assesment items'
+        # created in right order?
+        assert assessment_items[0].assessment_id == 'abf45e8fd7f151adb1b3df2d751e945e', 'created in wrong order'
+        assert assessment_items[1].assessment_id == '98856e24d53b57ea9023782ab6018767', 'created in wrong order'
+        # associated with content node c ?
+        for assessment_item in assessment_items:
+            assert assessment_item.contentnode == c, 'not associated with content node'
+
+    def test_exercise_image_files_associated_with_assesment_items(self):
+        """
+        Check that the files we created beforehand are now associated with the
+        correct assesment items.
+        """
+        c = ContentNode.objects.get(title=self.title)
+
+        question1 = c.assessment_items.get(assessment_id='abf45e8fd7f151adb1b3df2d751e945e')
+        assert len(question1.files.all()) == 1, 'wrong number of files'
+        file1 = question1.files.all()[0]
+        assert file1.assessment_item == question1, 'not associated with right assessment item'
+        assert file1.filename() == self.exercise_image.filename(), 'wrong file'
+        assert file1.file_on_disk.read() == self.exercise_image.file_on_disk.read(), 'different contents'
+
+        question2 = c.assessment_items.get(assessment_id='98856e24d53b57ea9023782ab6018767')
+        assert len(question2.files.all()) == 1, 'wrong number of files'
+        file2 = question2.files.all()[0]
+        assert file2.assessment_item == question2, 'not associated with right assessment item'
+        assert file2.filename() == self.exercise_graphie.filename(), 'wrong file'
+        assert file2.file_on_disk.read() == self.exercise_graphie.file_on_disk.read(), 'different contents'
+        assert file2.original_filename ==  self.exercise_graphie.original_filename, 'wrong original_filename'

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -1,12 +1,11 @@
-import os
+import logging
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.core.files import File as DjFile
 from django.core.files.storage import default_storage
-from django_s3_storage.storage import S3Error
 
-from contentcuration.models import Language, User, ContentNode, AssessmentItem, FormatPreset, generate_object_storage_name, File
+from contentcuration.models import AssessmentItem, ContentNode, File, FormatPreset, Language, User
+from contentcuration.models import generate_object_storage_name
 
 
 def map_files_to_node(user, node, data):

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -6,7 +6,8 @@ from django.core.files import File as DjFile
 from django.core.files.storage import default_storage
 from django_s3_storage.storage import S3Error
 
-from contentcuration.models import Language, User, ContentNode, FormatPreset, generate_object_storage_name, File
+from contentcuration.models import Language, User, ContentNode, AssessmentItem, FormatPreset, generate_object_storage_name, File
+
 
 def map_files_to_node(user, node, data):
     """
@@ -18,7 +19,7 @@ def map_files_to_node(user, node, data):
         assert isinstance(node, ContentNode)
         assert isinstance(data, list)
 
-    # filter for file data that's not empty;
+    # filter out file that are empty
     valid_data = filter_out_nones(data)
 
     for file_data in valid_data:
@@ -52,6 +53,43 @@ def map_files_to_node(user, node, data):
             file_size=file_data['size'],
             preset=kind_preset,
             language_id=file_data.get('language'),
+            uploaded_by=user,
+        )
+        resource_obj.file_on_disk.name = file_path
+        resource_obj.save()
+
+
+
+def map_files_to_assessment_item(user, assessment_item, data):
+    """
+    Generate files referenced in given assesment item (a.k.a. question).
+    """
+    if settings.DEBUG:
+        # assert that our parameters match expected values
+        assert isinstance(user, User)
+        assert isinstance(assessment_item, AssessmentItem)
+        assert isinstance(data, list)
+
+    # filter out file that are empty
+    valid_data = filter_out_nones(data)
+
+    for file_data in valid_data:
+        filename = file_data["filename"]
+        checksum, ext = filename.split(".")
+
+        file_path = generate_object_storage_name(checksum, filename)
+        storage = default_storage
+        if not storage.exists(file_path):
+            raise IOError('{} not found'.format(file_path))
+
+        resource_obj = File(
+            checksum=checksum,
+            assessment_item=assessment_item,
+            file_format_id=ext,
+            original_filename=file_data.get('original_filename') or 'file',
+            source_url=file_data.get('source_url'),
+            file_size=file_data['size'],
+            preset_id=file_data["preset"],   # assessment_item-files always have a preset
             uploaded_by=user,
         )
         resource_obj.file_on_disk.name = file_path


### PR DESCRIPTION
Hi Aron,

I imitated your approach to get rid of the `DjFile` call in the function `map_files_to_assessment_item` which is very similar to the function `map_files_to_node` you worked on. I think that was the underlying cause of https://github.com/learningequality/studio/issues/941 --- the timeout was caused by the exercise image files, not the content node files.

I'm opening this PR pointing at your current branch so you can merge it and keep the two file-improvements changes together.