### PR TITLE
Celery worker probe!

### DIFF
--- a/deploy/cloudprober.cfg
+++ b/deploy/cloudprober.cfg
@@ -40,4 +40,16 @@ probe {
   }
   interval_msec: 60000  # 60s
   timeout_msec: 1000   # 1s
+},
+
+probe {
+  name: "workers"
+  type: EXTERNAL
+  targets { dummy_targets {} }
+  external_probe {
+    mode: ONCE
+    command: "./probers/workers_probe.py"
+  }
+  interval_msec: 60000  # 60s
+  timeout_msec: 5000   # 5s
 }

--- a/deploy/probers/worker_probe.py
+++ b/deploy/probers/worker_probe.py
@@ -2,7 +2,8 @@
 
 from base import BaseProbe
 import sys
-sys.path.insert(1, '../../contentcuration')
+import os
+sys.path.insert(1, os.path.abspath('../../contentcuration'))
 from contentcuration import celery_app
 
 EXPECTED_WORKERS = {'celery'}

--- a/deploy/probers/worker_probe.py
+++ b/deploy/probers/worker_probe.py
@@ -5,19 +5,26 @@ import sys
 sys.path.insert(1, '../../contentcuration')
 from contentcuration import celery_app
 
+EXPECTED_WORKERS = {'celery'}
+
 class WorkerProbe(BaseProbe):
 
     metric = "worker_ping_latency_msec"
 
     def do_probe(self):
         workers = celery_app.control.inspect().ping()
-        # import pdb; pdb.set_trace()
+        workers_present = set()
+        get_worker_name = lambda worker: worker.split('@')[0]
         if not workers:
             raise Exception('No workers are running! Yikes!')
         else:
             for worker, info in workers.items():
                 if info[u'ok'] != 'pong':
-                    raise Exception('Worker %s responded with an unexpected status `%s`!  Yikes!' % (worker, info[u'ok']))
+                    raise Exception('Worker %s responded with an unexpected status `%s`!  Huh?' % (worker, info[u'ok']))
+                else:
+                    workers_present.add(get_worker_name(worker))
+            if workers_present != EXPECTED_WORKERS:
+                raise Exception('The set of currently instantiated workers did not match what was expected!')
 
 if __name__ == "__main__":
     WorkerProbe().run()

--- a/deploy/probers/worker_probe.py
+++ b/deploy/probers/worker_probe.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from base import BaseProbe
+import sys
+sys.path.insert(1, '../../contentcuration')
+from contentcuration import celery_app
+
+class WorkerProbe(BaseProbe):
+
+    metric = "worker_ping_latency_msec"
+
+    def do_probe(self):
+        workers = celery_app.control.inspect().ping()
+        # import pdb; pdb.set_trace()
+        if not workers:
+            raise Exception('No workers are running! Yikes!')
+        else:
+            for worker, info in workers.items():
+                if info[u'ok'] != 'pong':
+                    raise Exception('Worker %s responded with an unexpected status `%s`!  Yikes!' % (worker, info[u'ok']))
+
+if __name__ == "__main__":
+    WorkerProbe().run()


### PR DESCRIPTION
This adds a probe for pinging celery workers.  It also serves as an example of how to access studio code from a probe script.

## Description

This probe pings instantiated celery workers.  It raises errors in three cases:
- If no workers are found
- If workers respond with something other than 'pong'
- If the presently instantiated worker names do not match the expected set of worker names.
  - This will need to be adjusted in the future to account for dynamically spawned workers.

![image](https://user-images.githubusercontent.com/389782/56998622-c35a0580-6b60-11e9-8774-32ef4de77c6b.png)
