### PR TITLE
Postmark API status probe

### DIFF
--- a/deploy/cloudprober.cfg
+++ b/deploy/cloudprober.cfg
@@ -50,6 +50,6 @@ probe {
     mode: ONCE
     command: "./probers/postmark_api_probe.py"
   }
-  interval_msec: 5*60000  # 5 minutes
+  interval_msec: 300000  # 5 minutes
   timeout_msec: 5000   # 5s
 }

--- a/deploy/cloudprober.cfg
+++ b/deploy/cloudprober.cfg
@@ -41,3 +41,15 @@ probe {
   interval_msec: 60000  # 60s
   timeout_msec: 1000   # 1s
 }
+
+probe {
+  name: "postmark_api"
+  type: EXTERNAL
+  targets { dummy_targets {} }
+  external_probe {
+    mode: ONCE
+    command: "./probers/postmark_api_probe.py"
+  }
+  interval_msec: 5*60000  # 5 minutes
+  timeout_msec: 5000   # 5s
+}

--- a/deploy/probers/postmark_api_probe.py
+++ b/deploy/probers/postmark_api_probe.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import os
+import requests
+import datetime
+
+from base import BaseProbe
+
+POSTMARK_SERVICE_STATUS_URL = "https://status.postmarkapp.com/api/1.0/services"
+
+# (See here for API details: https://status.postmarkapp.com/api)
+ALL_POSSIBLE_STATUSES = ['UP', 'MAINTENANCE', 'DELAY', 'DEGRADED', 'DOWN']
+
+PASSING_POSTMARK_STATUSES = {
+    '/services/smtp': ['UP', 'MAINTENANCE'],
+    '/services/api': ALL_POSSIBLE_STATUSES,
+    '/services/inbound': ALL_POSSIBLE_STATUSES,
+    '/services/web': ALL_POSSIBLE_STATUSES
+}
+
+
+class PostmarkProbe(BaseProbe):
+
+    metric = "login_latency_msec"
+
+    def do_probe(self):
+        r = requests.get(url=POSTMARK_SERVICE_STATUS_URL)
+        for service in r.json():
+            allowed_statuses = PASSING_POSTMARK_STATUSES.get(service['url'])
+            passing = service['status'] in allowed_statuses
+
+            if passing:
+                continue
+            else:
+                raise Exception("Postmark's `%s` service has status %s, but we require one of the following: %s" % (
+                        service['name'],
+                        service['status'],
+                        allowed_statuses
+                    )
+                )
+
+
+if __name__ == "__main__":
+    PostmarkProbe().run()


### PR DESCRIPTION
This probe checks the [Postmark status API](https://status.postmarkapp.com/api) against a dictionary of desired statuses.

I'm not sure if it's calibrated right.  For example, do we want to be alerted if the Postmark `smtp` service's status is `DELAY`?  I'm not sure!