### PR TITLE
add probers for pinging facebook, postgres read/write contentnode checks

### DIFF
--- a/deploy/cloudprober.cfg
+++ b/deploy/cloudprober.cfg
@@ -53,3 +53,37 @@ probe {
   interval_msec: 60000  # 60s
   timeout_msec: 5000   # 5s
 }
+
+probe {
+  name: "facebook_homepage"
+  type: HTTP
+  targets {
+    host_names: "www.facebook.com"
+  }
+  interval_msec: 60000  # 60s
+  timeout_msec: 1000   # 1s
+}
+
+probe {
+  name: "postgres_read_contentnode"
+  type: EXTERNAL
+  targets { dummy_targets {} }
+  external_probe {
+    mode: ONCE
+    command: "./probers/postgres_read_contentnode_probe.py"
+  }
+  interval_msec: 60000  # 60s
+  timeout_msec: 1000   # 1s
+}
+
+probe {
+  name: "postgres_write_contentnode"
+  type: EXTERNAL
+  targets { dummy_targets {} }
+  external_probe {
+    mode: ONCE
+    command: "./probers/postgres_write_contentnode_probe.py"
+  }
+  interval_msec: 60000  # 60s
+  timeout_msec: 1000   # 1s
+}

--- a/deploy/probers/postgres_read_contentnode_probe.py
+++ b/deploy/probers/postgres_read_contentnode_probe.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import os
+
+import psycopg2
+from base import BaseProbe
+
+
+# Use dev options if no env set
+DB_HOST = os.getenv("DATA_DB_HOST") or "localhost"
+DB_PORT = 5432
+DB_NAME = os.getenv("DATA_DB_NAME") or "kolibri-studio"
+DB_USER = os.getenv("DATA_DB_USER") or "learningequality"
+DB_PASSWORD = os.getenv("DATA_DB_PASS") or "kolibri"
+TIMEOUT_SECONDS = 2
+
+
+class PostgresReadContentnodeProbe(BaseProbe):
+    metric = "postgres_read_contentnode_latency_msec"
+
+    def do_probe(self):
+        conn = psycopg2.connect(
+            host=DB_HOST,
+            port=DB_PORT,
+            dbname=DB_NAME,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            connect_timeout=TIMEOUT_SECONDS,
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM contentcuration_contentnode LIMIT 1;")
+        num = cur.fetchone()
+        conn.close()
+        if not num:
+            raise Exception("Reading a ContentNode in PostgreSQL database failed.")
+
+
+if __name__ == "__main__":
+    PostgresReadContentnodeProbe().run()

--- a/deploy/probers/postgres_write_contentnode_probe.py
+++ b/deploy/probers/postgres_write_contentnode_probe.py
@@ -27,8 +27,6 @@ class PostgresWriteContentnodeProbe(BaseProbe):
             connect_timeout=TIMEOUT_SECONDS,
         )
         cur = conn.cursor()
-        cur.execute("SELECT * FROM contentcuration_contentnode;")
-        count_before = cur.rowcount
         now = datetime.now()
         cur.execute(
             """
@@ -57,11 +55,7 @@ class PostgresWriteContentnodeProbe(BaseProbe):
                 "test",
             ),
         )
-        cur.execute("SELECT * FROM contentcuration_contentnode;")
-        count_after = cur.rowcount
         conn.close()
-        if count_before + 1 != count_after:
-            raise Exception("Writing a ContentNode to PostgreSQL database failed.")
 
 
 if __name__ == "__main__":

--- a/deploy/probers/postgres_write_contentnode_probe.py
+++ b/deploy/probers/postgres_write_contentnode_probe.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+import os
+from datetime import datetime
+
+import psycopg2
+from base import BaseProbe
+
+# Use dev options if no env set
+DB_HOST = os.getenv("DATA_DB_HOST") or "localhost"
+DB_PORT = 5432
+DB_NAME = os.getenv("DATA_DB_NAME") or "kolibri-studio"
+DB_USER = os.getenv("DATA_DB_USER") or "learningequality"
+DB_PASSWORD = os.getenv("DATA_DB_PASS") or "kolibri"
+TIMEOUT_SECONDS = 2
+
+
+class PostgresWriteContentnodeProbe(BaseProbe):
+    metric = "postgres_write_contentnode_latency_msec"
+
+    def do_probe(self):
+        conn = psycopg2.connect(
+            host=DB_HOST,
+            port=DB_PORT,
+            dbname=DB_NAME,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            connect_timeout=TIMEOUT_SECONDS,
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM contentcuration_contentnode;")
+        count_before = cur.rowcount
+        now = datetime.now()
+        cur.execute(
+            """
+            INSERT INTO contentcuration_contentnode(id, content_id, kind_id, title, description,sort_order, created,
+            modified, changed, lft, rght, tree_id, level, published, node_id, freeze_authoring_data, publishing, role_visibility)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+            """,
+            (
+                "testpostgreswriteprobe",
+                "testprobecontentid",
+                "topic",
+                "test postgres write contentnode probe",
+                "test postgres write contentnode probe",
+                1,
+                now,
+                now,
+                True,
+                1,
+                1,
+                1,
+                1,
+                False,
+                "testprobenodeid",
+                False,
+                False,
+                "test",
+            ),
+        )
+        cur.execute("SELECT * FROM contentcuration_contentnode;")
+        count_after = cur.rowcount
+        conn.close()
+        if count_before + 1 != count_after:
+            raise Exception("Writing a ContentNode to PostgreSQL database failed.")
+
+
+if __name__ == "__main__":
+    PostgresWriteContentnodeProbe().run()


### PR DESCRIPTION
Not quite sure about the postgres write contentnode probe:
- Should I commit the transaction? I'm afraid that the test data here would cause an issue.

Also I end up writing the two checks for postgres in separate probers instead of putting them on top of Kevin's prober, since it will be easier to check each operation's latency. But if it's better to put them all together to save the time of connecting to the database, I can put them together. :)
Please feel free to leave comments in the PR. Thank you so much! 