### PR TITLE
Add cloudprobers to the dev docker-compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	yarn install && yarn run unittests
 
 endtoendtest:
-	# launch all studio's dependent services using docker-compose, and then run the tests
+	# launch all studio's dependent services using docker-compose, and then run the tests	
 	docker-compose run studio-app make test -e DJANGO_SETTINGS_MODULE=contentcuration.test_settings
 
 collectstatic: migrate
@@ -67,8 +67,11 @@ docs: clean-docs
 setup:
 	python contentcuration/manage.py setup
 
+export COMPOSE_PROJECT_NAME=studio_$(shell git rev-parse --abbrev-ref HEAD)
+
+
 dcbuild:
-	# bild all studio docker image and all dependent services using docker-compose
+	# build all studio docker image and all dependent services using docker-compose
 	docker-compose build
 
 dcup:
@@ -84,9 +87,10 @@ dcclean:
 	docker-compose down -v
 	docker image prune -f
 
+export STUDIO_APP = ${COMPOSE_PROJECT_NAME}_studio-app_1
 dcshell:
 	# bash shell inside studio-app container
-	docker exec -ti studio_studio-app_1 /usr/bin/fish
+	docker exec -ti ${STUDIO_APP} /usr/bin/fish 
 
 dctest: endtoendtest
 	# launch all studio's dependent services using docker-compose, and then run the tests

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,11 @@ dcbuild:
 	docker-compose build
 
 dcup:
-	# run make deverver in foreground with all dependent services using docker-compose
+	# run all services except for cloudprober
+	docker-compose up studio-app celery-worker
+
+dcup-cloudprober:
+	# run all services including cloudprober
 	docker-compose up
 
 dcdown:
@@ -87,10 +91,10 @@ dcclean:
 	docker-compose down -v
 	docker image prune -f
 
-export STUDIO_APP = ${COMPOSE_PROJECT_NAME}_studio-app_1
+export COMPOSE_STUDIO_APP = ${COMPOSE_PROJECT_NAME}_studio-app_1
 dcshell:
 	# bash shell inside studio-app container
-	docker exec -ti ${STUDIO_APP} /usr/bin/fish 
+	docker exec -ti ${COMPOSE_STUDIO_APP} /usr/bin/fish 
 
 dctest: endtoendtest
 	# launch all studio's dependent services using docker-compose, and then run the tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,59 +1,44 @@
-version: '3'
+version: '3.4'
+
+x-studio-environment:
+  &studio-environment
+      MPLBACKEND: ps
+      SHELL: /bin/bash
+      AWS_S3_ENDPOINT_URL: http://minio:9000
+      DATA_DB_HOST: postgres
+      DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
+      RUN_MODE: docker-compose
+      CELERY_TIMEZONE: America/Los_Angeles
+      CELERY_REDIS_DB: 0
+      CELERY_BROKER_ENDPOINT: redis
+      CELERY_RESULT_BACKEND_ENDPOINT: redis
+      CELERY_REDIS_PASSWORD: ""
+
+x-studio-worker:
+  &studio-worker
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.dev
+    image: learningequality/studio-app-dev
+    depends_on:
+      - minio
+      - postgres
+      - redis
+    volumes:
+      - .:/src
+  environment: *studio-environment
 
 services:
-
   studio-app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.dev
-    image: learningequality/studio-app-dev
+    <<: *studio-worker
     entrypoint: python docker/entrypoint.py
     command: yarn run devserver
-    depends_on:
-      - minio
-      - postgres
-      - redis
     ports:
       - "8080:8080"
-    environment:
-      MPLBACKEND: ps
-      SHELL: /bin/bash
-      AWS_S3_ENDPOINT_URL: http://minio:9000
-      DATA_DB_HOST: postgres
-      DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
-      RUN_MODE: docker-compose
-      CELERY_TIMEZONE: America/Los_Angeles
-      CELERY_REDIS_DB: 0
-      CELERY_BROKER_ENDPOINT: redis
-      CELERY_RESULT_BACKEND_ENDPOINT: redis
-      CELERY_REDIS_PASSWORD: ""
-    volumes:
-      - .:/src
 
-  worker:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.dev
-    image: learningequality/studio-app-dev
+  celery-worker:
+    <<: *studio-worker
     command: make prodceleryworkers
-    depends_on:
-      - minio
-      - postgres
-      - redis
-    volumes:
-      - .:/src
-    environment:
-      MPLBACKEND: ps
-      SHELL: /bin/bash
-      AWS_S3_ENDPOINT_URL: http://minio:9000
-      DATA_DB_HOST: postgres
-      DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
-      RUN_MODE: docker-compose
-      CELERY_TIMEZONE: America/Los_Angeles
-      CELERY_REDIS_DB: 0
-      CELERY_BROKER_ENDPOINT: redis
-      CELERY_RESULT_BACKEND_ENDPOINT: redis
-      CELERY_REDIS_PASSWORD: ""
 
   minio:
     image: minio/minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,26 +11,26 @@ services:
     command: yarn run devserver
     depends_on:
       - minio
-      - studio-postgres
-      - studio-redis
+      - postgres
+      - redis
     ports:
       - "8080:8080"
     environment:
       MPLBACKEND: ps
       SHELL: /bin/bash
       AWS_S3_ENDPOINT_URL: http://minio:9000
-      DATA_DB_HOST: studio-postgres
+      DATA_DB_HOST: postgres
       DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
       RUN_MODE: docker-compose
       CELERY_TIMEZONE: America/Los_Angeles
       CELERY_REDIS_DB: 0
-      CELERY_BROKER_ENDPOINT: studio-redis
-      CELERY_RESULT_BACKEND_ENDPOINT: studio-redis
+      CELERY_BROKER_ENDPOINT: redis
+      CELERY_RESULT_BACKEND_ENDPOINT: redis
       CELERY_REDIS_PASSWORD: ""
     volumes:
       - .:/src
 
-  studio-worker:
+  worker:
     build:
       context: .
       dockerfile: docker/Dockerfile.dev
@@ -38,21 +38,21 @@ services:
     command: make prodceleryworkers
     depends_on:
       - minio
-      - studio-postgres
-      - studio-redis
+      - postgres
+      - redis
     volumes:
       - .:/src
     environment:
       MPLBACKEND: ps
       SHELL: /bin/bash
       AWS_S3_ENDPOINT_URL: http://minio:9000
-      DATA_DB_HOST: studio-postgres
+      DATA_DB_HOST: postgres
       DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
       RUN_MODE: docker-compose
       CELERY_TIMEZONE: America/Los_Angeles
       CELERY_REDIS_DB: 0
-      CELERY_BROKER_ENDPOINT: studio-redis
-      CELERY_RESULT_BACKEND_ENDPOINT: studio-redis
+      CELERY_BROKER_ENDPOINT: redis
+      CELERY_RESULT_BACKEND_ENDPOINT: redis
       CELERY_REDIS_PASSWORD: ""
 
   minio:
@@ -66,7 +66,7 @@ services:
     ports:
       - "9000:9000"
 
-  studio-postgres:
+  postgres:
     image: postgres:9.6
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
@@ -76,7 +76,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data/pgdata
 
-  studio-redis:
+  redis:
     image: redis:4.0.9
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ version: '3.4'
 
 x-studio-environment:
   &studio-environment
-      MPLBACKEND: ps
-      SHELL: /bin/bash
-      AWS_S3_ENDPOINT_URL: http://minio:9000
-      DATA_DB_HOST: postgres
-      DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
-      RUN_MODE: docker-compose
-      CELERY_TIMEZONE: America/Los_Angeles
-      CELERY_REDIS_DB: 0
-      CELERY_BROKER_ENDPOINT: redis
-      CELERY_RESULT_BACKEND_ENDPOINT: redis
-      CELERY_REDIS_PASSWORD: ""
+    MPLBACKEND: ps
+    SHELL: /bin/bash
+    AWS_S3_ENDPOINT_URL: http://minio:9000
+    DATA_DB_HOST: postgres
+    DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
+    RUN_MODE: docker-compose
+    CELERY_TIMEZONE: America/Los_Angeles
+    CELERY_REDIS_DB: 0
+    CELERY_BROKER_ENDPOINT: redis
+    CELERY_RESULT_BACKEND_ENDPOINT: redis
+    CELERY_REDIS_PASSWORD: ""
 
 x-studio-worker:
   &studio-worker
@@ -26,7 +26,7 @@ x-studio-worker:
       - redis
     volumes:
       - .:/src
-  environment: *studio-environment
+    environment: *studio-environment
 
 services:
   studio-app:
@@ -63,6 +63,15 @@ services:
 
   redis:
     image: redis:4.0.9
+
+  cloudprober:
+    <<: *studio-worker
+    working_dir: /src/deploy
+    command: /bin/cloudprober --config_file ./cloudprober.cfg
+    # wait until the main app and celery worker have started
+    depends_on:
+      - studio-app
+      - celery-worker
 
 
 volumes:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN apt-get -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get -y install nodejs python python-dev \
     fish man \
-    python-pip gcc libpq-dev ffmpeg imagemagick \
+    python-pip gcc libpq-dev ffmpeg imagemagick unzip \
     ghostscript python-tk make git gettext openjdk-9-jre-headless libjpeg-dev \
     wkhtmltopdf fonts-freefont-ttf xfonts-75dpi poppler-utils
 RUN curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb && dpkg -i wkhtmltox.deb
@@ -32,6 +32,13 @@ COPY Pipfile Pipfile.lock   /src/
 RUN pip install -U pipenv
 # install packages from Pipfile.lock into system
 RUN pipenv install --dev --system --ignore-pipfile
+################################################################################
+
+
+# Cloudprober binary ###########################################################
+RUN curl -L -o /cloudprober.zip https://github.com/google/cloudprober/releases/download/v0.10.2/cloudprober-v0.10.2-linux-x86_64.zip
+RUN unzip -p /cloudprober.zip > /bin/cloudprober
+RUN chmod +x /bin/cloudprober
 ################################################################################
 
 


### PR DESCRIPTION
This change is intended to aid with testing out `cloudprobers` in a more production-like environment. 

### Changes
#### `docker/Dockerfile.dev`
- Install cloudprobers
#### `docker-compose.yml`
- Use YAML anchors to make easier reuse of docker-compose worker environment variables
- Renames some docker-compose services.  E.g. removing "studio-" from most service names since "studio_*<git-branch-name>*- will now be prepended via the docker-compose project name (see below).  - The default celery worker has been renamed to from "studio-worker" to "celery-worker".
- Add a `cloudprobers` service to `docker-compose.yml`
#### `Makefile`
- Set the default docker-compose project name (`COMPOSE_PROJECT_NAME`) based on the currently checked out git branch name.  E.g. if you're working on a branch called `probers`, the docker-compose project will be called `studio_probers`.  Previously, the default was set to the name of the directory which the source is checked out into.  That made it difficult to use `docker-compose` simultaneously on different branches, increasing the friction of switching contexts.
- `make dcshell` will now work even if your working source directory isn't called `studio`
- `make dcup` doesn't start the `cloudprobers` service by default
- use `make dcup-cloudprobers` to start the `cloudprobers` service

## before:
![image](https://user-images.githubusercontent.com/389782/57171234-0a9dfb80-6dd8-11e9-96dd-d8caf160d758.png)

## after:
![image](https://user-images.githubusercontent.com/389782/57171229-0245c080-6dd8-11e9-81e9-0cac2aae961a.png)